### PR TITLE
Adicionado arquivo de code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gledsoncr @jampow @lvolcov


### PR DESCRIPTION
O arquivo de code owners do github é um lugar para discriminar todos os usuários que devem aprovar alterações em certas partes do projeto ou em todo o projeto.

Mais sobre isso pode ser lido na [doc oficial do github](https://docs.github.com/pt/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners)